### PR TITLE
Update README.md

### DIFF
--- a/packages/gatsby-source-wordpress/README.md
+++ b/packages/gatsby-source-wordpress/README.md
@@ -50,4 +50,4 @@ This plugin works by merging the [WPGraphQL schema & data](https://docs.wpgraphq
 - [WPGatsby](https://github.com/gatsbyjs/wp-gatsby)
 - [WPGraphQL](https://github.com/wp-graphql/wp-graphql)
 - [Gatsby](https://www.gatsbyjs.com/)
-- [WordPress](https://wordpress.com/)
+- [WordPress](https://wordpress.org/)


### PR DESCRIPTION
HyperLink on WordPress needs to be checked.
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

In this PR, I am suggesting an edit to the hyperlink on WordPress. Instead of linking to the commercial platform, we would ideally want to link the open-source WordPress.org 
### Documentation
For instance, on the [Getting Ready](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/getting-started.md#wordpress) page, the correct link is used.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
